### PR TITLE
Use "Unix Makefiles" build system generator if ninja is not installed

### DIFF
--- a/_custom_build/backend.py
+++ b/_custom_build/backend.py
@@ -65,12 +65,13 @@ def _ninja_required():
         print("Ninja is part of the MSVC installation on Windows")
         return False
 
-    try:
-        _subprocess.check_output(["ninja", '--version'])
-        print("Using System version of Ninja")
-        return False
-    except (OSError, _subprocess.CalledProcessError):
-        pass
+    for generator in ("ninja", "make"):
+        try:
+            _subprocess.check_output([generator, '--version'])
+            print(f"Using System version of {generator}")
+            return False
+        except (OSError, _subprocess.CalledProcessError):
+            pass
 
     for tag in _sys_tags():
         if tag.platform in ninja_wheels:


### PR DESCRIPTION
Scikit-build [automatically falls back](https://scikit-build.readthedocs.io/en/latest/generators.html#build-system-generator) to using `make` on Linux and Mac if ninja is not available.